### PR TITLE
Improve AppleCare device status logic and UI alignment

### DIFF
--- a/applecare_model.php
+++ b/applecare_model.php
@@ -7,6 +7,10 @@ class Applecare_model extends Eloquent
 {
     protected $table = 'applecare';
 
+    // Primary key is a string (API ID like "TW1C6LYF46"), not auto-incrementing integer
+    protected $keyType = 'string';
+    public $incrementing = false;
+
     protected $hidden = ['id', 'serial_number'];
 
     protected $fillable = [
@@ -40,6 +44,8 @@ class Applecare_model extends Eloquent
         'last_updated',
         'last_fetched',
         'sync_in_progress',
+        'is_primary',
+        'coverage_status',
     ];
 
     /**

--- a/applecare_processor.php
+++ b/applecare_processor.php
@@ -61,7 +61,9 @@ class Applecare_processor extends Processor
                     } else {
                         $message = isset($result['message']) ? $result['message'] : 'Unknown error';
                         // Don't log "API not configured" - this is expected for devices without config
-                        if (strpos($message, 'AppleCare API not configured') === false) {
+                        // Don't log "SKIP (HTTP 404)" - this is expected for devices not found in Apple Business/School Manager
+                        if (strpos($message, 'AppleCare API not configured') === false && 
+                            strpos($message, 'SKIP (HTTP 404)') === false) {
                             error_log("AppleCare: Sync failed for {$this->serial_number}: $message");
                         }
                     }

--- a/js/applecare.js
+++ b/js/applecare.js
@@ -40,8 +40,8 @@ var format_applecare_enrolled_in_dep = function(colNumber, row){
 
 // Helper function to find end date in nearby columns
 var findEndDateInRow = function(colNumber, row) {
-    // Try known column offset first (endDateTime is typically 3 columns after status)
-    var endDateCol = $('td:eq('+(colNumber+3)+')', row);
+    // Try known column offset first (endDateTime is 6 columns after status based on applecare_listing.yml)
+    var endDateCol = $('td:eq('+(colNumber+6)+')', row);
     if (endDateCol.length) {
         var endDateText = endDateCol.text();
         if (endDateText && (/^\d{4}-\d{2}-\d{2}/.test(endDateText) || moment(endDateText).isValid())) {
@@ -49,8 +49,8 @@ var findEndDateInRow = function(colNumber, row) {
         }
     }
     
-    // Search nearby columns if not found
-    for (var i = colNumber + 1; i < colNumber + 6; i++) {
+    // Search nearby columns if not found (expanded range)
+    for (var i = colNumber + 1; i < colNumber + 8; i++) {
         var testCol = $('td:eq('+i+')', row);
         var testText = testCol.text();
         if (testText && (/^\d{4}-\d{2}-\d{2}/.test(testText) || moment(testText).isValid())) {
@@ -89,14 +89,14 @@ var format_applecare_status = function(colNumber, row){
         var rowData = oTable.row(row).data();
         var endDateText = null;
         
-        // endDateTime column index calculation:
-        // status=colNumber, device_assignment_status=colNumber+1, description=colNumber+2, 
-        // purchase_source_id=colNumber+3, startDateTime=colNumber+4, endDateTime=colNumber+5
-        if (rowData && Array.isArray(rowData) && rowData[colNumber + 5]) {
-            endDateText = rowData[colNumber + 5];
+        // endDateTime column index calculation (based on applecare_listing.yml):
+        // status=colNumber (3), device_assignment_status=+1, enrolled_in_dep=+2, description=+3, 
+        // purchase_source_id=+4, startDateTime=+5, endDateTime=+6
+        if (rowData && Array.isArray(rowData) && rowData[colNumber + 6]) {
+            endDateText = rowData[colNumber + 6];
         } else {
             // Fallback: try to get from DOM
-            var endDateCol = $('td:eq('+(colNumber+5)+')', row);
+            var endDateCol = $('td:eq('+(colNumber+6)+')', row);
             if (endDateCol.length) {
                 // Get the raw text first (before any formatting)
                 endDateText = endDateCol.text();

--- a/locales/en.json
+++ b/locales/en.json
@@ -31,7 +31,7 @@
         "bluetooth_mac_address": "Bluetooth MAC Address"
     },
     "device_info": {
-        "title": "Device Information"
+        "title": "AxM Device Information"
     },
     "coverage_info": {
         "title": "AppleCare Coverage"

--- a/locales/en.json
+++ b/locales/en.json
@@ -28,7 +28,9 @@
         "released_from_org_date": "Released from Org Date",
         "wifi_mac_address": "Wi-Fi MAC Address",
         "ethernet_mac_address": "Ethernet MAC Address",
-        "bluetooth_mac_address": "Bluetooth MAC Address"
+        "bluetooth_mac_address": "Bluetooth MAC Address",
+        "coverage_status": "Coverage Status",
+        "is_primary": "Primary Plan"
     },
     "device_info": {
         "title": "AxM Device Information"
@@ -50,10 +52,19 @@
     "widget_tooltip": "Shows count of devices with AppleCare coverage. Green indicates devices with active coverage, yellow indicates devices with coverage expiring soon, red indicates devices with expired coverage.",
     "total_devices": "Total Devices",
     "active": "Active",
+    "active_tooltip": "Devices with active AppleCare coverage",
+    "active_title": "Devices with Active AppleCare",
+    "active_description": "Devices with active AppleCare coverage (not expiring within 30 days).",
     "expiring_soon": "Expiring Soon",
-    "expiring_soon_tooltip": "Devices with coverage expiring within 30 days",
+    "expiring_soon_tooltip": "Devices whose only active coverage expires within 30 days",
+    "expiring_soon_title": "Devices with Expiring AppleCare",
+    "expiring_soon_description": "Devices whose only active AppleCare coverage expires within 30 days.",
+    "back_to_full_listing": "Back to Full Listing",
     "expired": "Expired",
     "inactive": "Expired",
+    "inactive_tooltip": "Devices with no active AppleCare coverage",
+    "inactive_title": "Devices with Expired AppleCare",
+    "inactive_description": "Devices with no active AppleCare coverage (all plans expired or inactive).",
     "sync_now": "Sync Now",
     "widget": {
         "status_title": "Status",

--- a/migrations/2026_01_21_000001_add_is_primary.php
+++ b/migrations/2026_01_21_000001_add_is_primary.php
@@ -1,0 +1,138 @@
+<?php
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+class AddIsPrimary extends Migration
+{
+    public function up()
+    {
+        $capsule = new Capsule();
+        
+        // Add is_primary and coverage_status columns
+        $capsule::schema()->table('applecare', function (Blueprint $table) {
+            $table->boolean('is_primary')->default(0)->after('isCanceled');
+            $table->string('coverage_status', 20)->nullable()->after('is_primary');
+            $table->index('is_primary');
+            $table->index('coverage_status');
+            $table->index(['serial_number', 'is_primary']);
+        });
+        
+        // Mark "the one" for each device and set coverage_status
+        $this->markPrimaryPlans();
+    }
+
+    public function down()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->table('applecare', function (Blueprint $table) {
+            $table->dropIndex(['applecare_is_primary_index']);
+            $table->dropIndex(['applecare_coverage_status_index']);
+            $table->dropIndex(['applecare_serial_number_is_primary_index']);
+            $table->dropColumn(['is_primary', 'coverage_status']);
+        });
+    }
+    
+    /**
+     * Mark the primary plan for each device and set coverage_status
+     */
+    private function markPrimaryPlans()
+    {
+        $now = date('Y-m-d');
+        $thirtyDays = date('Y-m-d', strtotime('+30 days'));
+        
+        // Get all unique serial numbers
+        $serials = Capsule::table('applecare')
+            ->distinct()
+            ->pluck('serial_number');
+        
+        foreach ($serials as $serial) {
+            if (empty($serial)) {
+                continue;
+            }
+            
+            // Get all plans for this device
+            $plans = Capsule::table('applecare')
+                ->where('serial_number', $serial)
+                ->get();
+            
+            if ($plans->isEmpty()) {
+                continue;
+            }
+            
+            // Find the primary plan and determine coverage status
+            $result = $this->findPrimaryPlanAndStatus($plans, $now, $thirtyDays);
+            
+            if ($result['id']) {
+                // Mark this plan as primary with coverage_status
+                Capsule::table('applecare')
+                    ->where('id', $result['id'])
+                    ->update([
+                        'is_primary' => 1,
+                        'coverage_status' => $result['coverage_status']
+                    ]);
+            }
+        }
+    }
+    
+    /**
+     * Find the primary plan for a device and determine its coverage status
+     * 
+     * Logic (same as tab's get_data):
+     * - Pick the plan with the latest end date (treating null as very old date)
+     * - This is the "most relevant" plan for display purposes
+     * 
+     * Coverage status is then determined based on the primary plan:
+     * - "active": Plan is active (status=ACTIVE, not canceled, end date > 30 days from now)
+     * - "expiring_soon": Plan is active but end date <= 30 days from now
+     * - "inactive": Plan is not active (status != ACTIVE, or canceled, or end date in past)
+     * 
+     * @param \Illuminate\Support\Collection $plans
+     * @param string $now
+     * @param string $thirtyDays
+     * @return array ['id' => string|null, 'coverage_status' => string]
+     */
+    private function findPrimaryPlanAndStatus($plans, $now, $thirtyDays)
+    {
+        $allPlans = [];
+        
+        foreach ($plans as $plan) {
+            $allPlans[] = $plan;
+        }
+        
+        // Pick the plan with the latest end date (same logic as tab's get_data)
+        // Treat null end dates as very old (1970-01-01)
+        usort($allPlans, function($a, $b) {
+            $aEnd = $a->endDateTime ?? '1970-01-01';
+            $bEnd = $b->endDateTime ?? '1970-01-01';
+            return strcmp($bEnd, $aEnd); // Descending order
+        });
+        
+        $primary = $allPlans[0] ?? null;
+        
+        if (!$primary) {
+            return ['id' => null, 'coverage_status' => 'inactive'];
+        }
+        
+        // Determine coverage status based on the primary plan
+        $status = strtoupper($primary->status ?? '');
+        $isCanceled = !empty($primary->isCanceled);
+        $endDate = $primary->endDateTime;
+        
+        // Check if plan is active (status=ACTIVE, not canceled, end date in future)
+        $isActive = $status === 'ACTIVE' 
+            && !$isCanceled 
+            && !empty($endDate) 
+            && $endDate >= $now;
+        
+        if ($isActive) {
+            // Active - check if expiring soon
+            $coverageStatus = ($endDate <= $thirtyDays) ? 'expiring_soon' : 'active';
+        } else {
+            // Inactive (expired, canceled, or status != ACTIVE)
+            $coverageStatus = 'inactive';
+        }
+        
+        return ['id' => $primary->id, 'coverage_status' => $coverageStatus];
+    }
+}

--- a/sync_applecare.php
+++ b/sync_applecare.php
@@ -221,9 +221,16 @@ $skipped = 0;
 // This provides smoother rate limiting than fixed windows
 $request_timestamps = [];
 
+// Calculate devices per minute based on rate limit
+// Each device requires 2 API calls, and we use 80% of limit
+$effective_rate_limit = (int)($rate_limit * 0.8);
+$requests_per_device = 2;
+$devices_per_minute = $effective_rate_limit / $requests_per_device;
+
 echo "\nStarting sync...\n";
-echo "Rate limit: $rate_limit calls per minute\n";
-echo "Estimated time: " . ceil($total_devices / $rate_limit) . " minutes\n\n";
+echo "Rate limit: $rate_limit calls per minute (using 80% = $effective_rate_limit)\n";
+echo "Devices per minute: " . round($devices_per_minute, 1) . "\n";
+echo "Estimated time: " . ceil($total_devices / $devices_per_minute) . " minutes\n\n";
 
 foreach ($devices as $device) {
     $serial = $device->serial_number;

--- a/views/applecare_device_assignment_widget.yml
+++ b/views/applecare_device_assignment_widget.yml
@@ -8,10 +8,10 @@ listing_link: /show/listing/applecare/applecare
 buttons:
   - label: Assigned
     class: btn-success
-    search_component: assigned
+    search_component: is_primary=1&device_assignment_status=assigned
   - label: Unassigned
     class: btn-warning
-    search_component: unassigned
+    search_component: is_primary=1&device_assignment_status=unassigned
   - label: Released
     class: btn-danger
-    search_component: DEVICE_ASSIGNMENT_UNKNOWN
+    search_component: is_primary=1&device_assignment_status=DEVICE_ASSIGNMENT_UNKNOWN

--- a/views/applecare_enrolled_in_dep_widget.yml
+++ b/views/applecare_enrolled_in_dep_widget.yml
@@ -9,8 +9,8 @@ buttons:
   - label: 1
     i18n_label: yes
     class: btn-success
-    search_component: enrolled_in_dep=1
+    search_component: is_primary=1&enrolled_in_dep=1
   - label: 0
     i18n_label: no
     class: btn-danger
-    search_component: enrolled_in_dep=0
+    search_component: is_primary=1&enrolled_in_dep=0

--- a/views/applecare_listing.yml
+++ b/views/applecare_listing.yml
@@ -10,10 +10,10 @@ table:
         i18n_header: serial
     -   column: reportdata.long_username
         i18n_header: username
-    -   column: applecare.status
-        i18n_header: applecare.column.status
-        formatter: format_applecare_status
-        filter: status_filter
+    -   column: applecare.coverage_status
+        i18n_header: applecare.column.coverage_status
+        formatter: format_applecare_coverage_status
+        filter: coverage_status_filter
     -   column: applecare.device_assignment_status
         i18n_header: applecare.column.device_assignment_status
         formatter: format_applecare_device_assignment_status
@@ -49,3 +49,7 @@ table:
     #     i18n_header: applecare.column.contractCancelDateTime
     -   column: applecare.agreementNumber
         i18n_header: applecare.column.agreementNumber
+    -   column: applecare.is_primary
+        i18n_header: applecare.column.is_primary
+        formatter: format_applecare_is_primary
+        filter: is_primary_filter

--- a/views/applecare_tab.php
+++ b/views/applecare_tab.php
@@ -233,7 +233,7 @@ $(document).on('appReady', function(){
                     var td = $('<td>');
                     
                     // Format status with colors (capitalize first letter only)
-                    // Check end date for 31-day warning
+                    // Check end date for expired/expiring status
                     if (key === 'status') {
                         var statusUpper = String(data[key]).toUpperCase();
                         var statusDisplay = data[key].charAt(0).toUpperCase() + data[key].slice(1).toLowerCase();
@@ -241,24 +241,27 @@ $(document).on('appReady', function(){
                         
                         if (statusUpper === 'ACTIVE') {
                             var tooltipText = '';
-                            // Check if endDateTime exists and is less than 31 days away
+                            labelClass = 'label-success';
+                            
+                            // Check if endDateTime exists
                             if (data.endDateTime) {
                                 var parsedEndDate = moment(data.endDateTime, ['YYYY-MM-DD', 'YYYY-MM-DD HH:mm:ss'], true);
                                 if (parsedEndDate.isValid()) {
-                                    var now = moment();
+                                    var now = moment().startOf('day');
                                     var daysUntil = parsedEndDate.diff(now, 'days');
-                                    // If end date is less than 31 days away, use yellow warning
-                                    if (daysUntil >= 0 && daysUntil < 31) {
+                                    
+                                    if (daysUntil < 0) {
+                                        // End date is in the past - coverage has expired
+                                        labelClass = 'label-danger';
+                                        statusDisplay = i18n.t('applecare.expired') || 'Expired';
+                                        var daysAgo = Math.abs(daysUntil);
+                                        tooltipText = 'Coverage expired ' + daysAgo + ' day' + (daysAgo !== 1 ? 's' : '') + ' ago';
+                                    } else if (daysUntil < 31) {
+                                        // Expiring within 30 days
                                         labelClass = 'label-warning';
                                         tooltipText = 'Coverage expires in ' + daysUntil + ' day' + (daysUntil !== 1 ? 's' : '');
-                                    } else {
-                                        labelClass = 'label-success';
                                     }
-                                } else {
-                                    labelClass = 'label-success';
                                 }
-                            } else {
-                                labelClass = 'label-success';
                             }
                             var statusHtml = '<span class="label ' + labelClass + '"';
                             if (tooltipText) {

--- a/views/applecare_total_detail_widget.php
+++ b/views/applecare_total_detail_widget.php
@@ -33,12 +33,21 @@ $(document).on('appUpdate', function(e, lang) {
             baseUrl = appUrl + '/show/listing/applecare/applecare#';
         panel.empty();
 
-        // $('#applecare-widget .applecare_counter').html(data.total_devices);
-
-        // Set statuses - use regular links like other modules (green, yellow, red order)
-        panel.append(' <a href="'+baseUrl+'status=ACTIVE" class="btn btn-success"><span class="bigger-150">'+data.active+'</span><br>'+i18n.t('applecare.active')+'</a>');
+        // Active: is_primary=1 and coverage_status=active
+        var activeLink = $('<a>')
+            .attr('href', baseUrl + 'is_primary=1&coverage_status=active')
+            .addClass('btn btn-success')
+            .attr('title', i18n.t('applecare.active_tooltip'))
+            .attr('data-toggle', 'tooltip')
+            .attr('data-placement', 'top')
+            .append($('<span>').addClass('bigger-150').text(data.active))
+            .append('<br>')
+            .append(document.createTextNode(i18n.t('applecare.active')));
+        panel.append(activeLink);
+        
+        // Expiring Soon: is_primary=1 and coverage_status=expiring_soon
         var expiringLink = $('<a>')
-            .attr('href', baseUrl+'expiring=1')
+            .attr('href', baseUrl + 'is_primary=1&coverage_status=expiring_soon')
             .addClass('btn btn-warning')
             .attr('title', i18n.t('applecare.expiring_soon_tooltip'))
             .attr('data-toggle', 'tooltip')
@@ -47,7 +56,18 @@ $(document).on('appUpdate', function(e, lang) {
             .append('<br>')
             .append(document.createTextNode(i18n.t('applecare.expiring_soon')));
         panel.append(expiringLink);
-        panel.append(' <a href="'+baseUrl+'status=INACTIVE" class="btn btn-danger"><span class="bigger-150">'+data.inactive+'</span><br>'+i18n.t('applecare.inactive')+'</a>');
+        
+        // Inactive/Expired: is_primary=1 and coverage_status=inactive
+        var inactiveLink = $('<a>')
+            .attr('href', baseUrl + 'is_primary=1&coverage_status=inactive')
+            .addClass('btn btn-danger')
+            .attr('title', i18n.t('applecare.inactive_tooltip'))
+            .attr('data-toggle', 'tooltip')
+            .attr('data-placement', 'top')
+            .append($('<span>').addClass('bigger-150').text(data.inactive))
+            .append('<br>')
+            .append(document.createTextNode(i18n.t('applecare.inactive')));
+        panel.append(inactiveLink);
         
         // Initialize tooltips
         panel.find('[data-toggle="tooltip"]').tooltip();


### PR DESCRIPTION
Refactored device categorization in applecare_controller.php to group by serial number and select the best (latest, active) record per device, ensuring accurate status reporting. Simplified get_data to always return the record with the latest end date. Updated applecare_processor.php to suppress expected 404 errors from logs. Adjusted column offsets in js/applecare.js to match the current table structure. Updated device info title in en.json for consistency.