### PR TITLE
Increase AppleCare rate limit and added support for API 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add your AxM credentials to the `.env` file. Use [create_client_assertion.sh](ht
 # Apple Business Manager: https://api-business.apple.com/v1/
 APPLECARE_API_URL=https://api-school.apple.com/v1/
 APPLECARE_CLIENT_ASSERTION="Your Assertion String"
-APPLECARE_RATE_LIMIT=20  # Optional, default is 20 calls per minute
+APPLECARE_RATE_LIMIT=40  # Optional, default is 40 calls per minute
 ```
 
 **Multiple Organizations:**

--- a/applecare_controller.php
+++ b/applecare_controller.php
@@ -75,7 +75,7 @@ class Applecare_controller extends Module_controller
     {
         $api_url = null;
         $client_assertion = null;
-        $rate_limit = 20; // Default
+        $rate_limit = 40; // Default
         
         // Try machine group key prefix first
         $mg_key = $this->getMachineGroupKey($serial_number);
@@ -135,7 +135,7 @@ class Applecare_controller extends Module_controller
         }
         $default_rate_limit = getenv('APPLECARE_RATE_LIMIT');
         if (!empty($default_rate_limit)) {
-            $rate_limit = (int)$default_rate_limit ?: 20;
+            $rate_limit = (int)$default_rate_limit ?: 40;
         }
         
         // Return null if still not configured
@@ -585,7 +585,7 @@ class Applecare_controller extends Module_controller
         // Get default configuration from environment (for fallback)
         $default_api_base_url = getenv('APPLECARE_API_URL');
         $default_client_assertion = getenv('APPLECARE_CLIENT_ASSERTION');
-        $default_rate_limit = (int)getenv('APPLECARE_RATE_LIMIT') ?: 20;
+        $default_rate_limit = (int)getenv('APPLECARE_RATE_LIMIT') ?: 40;
 
         if (empty($default_client_assertion) && empty($default_api_base_url)) {
             $outputCallback("WARNING: Default APPLECARE_API_URL and APPLECARE_CLIENT_ASSERTION not set.");
@@ -1463,10 +1463,10 @@ class Applecare_controller extends Module_controller
         $data = [
             'api_url_configured' => false,
             'client_assertion_configured' => false,
-            'rate_limit' => 20,
+            'rate_limit' => 40,
             'default_api_url' => getenv('APPLECARE_API_URL') ?: '',
             'default_client_assertion' => getenv('APPLECARE_CLIENT_ASSERTION') ? 'Yes' : 'No',
-            'default_rate_limit' => getenv('APPLECARE_RATE_LIMIT') ?: '20',
+            'default_rate_limit' => getenv('APPLECARE_RATE_LIMIT') ?: '40',
             'max_execution_time' => $max_execution_time,
         ];
         
@@ -1500,12 +1500,12 @@ class Applecare_controller extends Module_controller
         // Get rate limit (check default first, then look for any org-specific)
         $rate_limit = getenv('APPLECARE_RATE_LIMIT');
         if (!empty($rate_limit)) {
-            $data['rate_limit'] = (int)$rate_limit ?: 20;
+            $data['rate_limit'] = (int)$rate_limit ?: 40;
         } else {
             // Check for org-specific rate limits
             foreach ($all_env as $key => $value) {
                 if (is_string($key) && preg_match('/^[A-Z0-9]+_APPLECARE_RATE_LIMIT$/', $key) && !empty($value)) {
-                    $data['rate_limit'] = (int)$value ?: 20;
+                    $data['rate_limit'] = (int)$value ?: 40;
                     break; // Use first found
                 }
             }

--- a/js/applecare.js
+++ b/js/applecare.js
@@ -116,7 +116,8 @@ var format_applecare_coverage_status = function(colNumber, row) {
         status = col.text();
     
     if (!status || status.trim() === '') {
-        col.html('');
+        // Show "Inactive" with grey label for records with no coverage_status
+        col.html('<span class="label label-default">' + i18n.t('applecare.no_coverage') + '</span>');
         return;
     }
     

--- a/lib/applecare_helper.php
+++ b/lib/applecare_helper.php
@@ -83,7 +83,7 @@ class Applecare_helper
     {
         $api_url = null;
         $client_assertion = null;
-        $rate_limit = 20;
+        $rate_limit = 40;
 
         // Try machine group key prefix first
         $mg_key = $this->getMachineGroupKey($serial_number);
@@ -143,7 +143,7 @@ class Applecare_helper
         }
         $default_rate_limit = getenv('APPLECARE_RATE_LIMIT');
         if (!empty($default_rate_limit)) {
-            $rate_limit = (int)$default_rate_limit ?: 20;
+            $rate_limit = (int)$default_rate_limit ?: 40;
         }
 
         if (empty($api_url) || empty($client_assertion)) {
@@ -417,9 +417,9 @@ class Applecare_helper
                         'order_date' => null,
                         'added_to_org_date' => null,
                         'released_from_org_date' => null,
-                        'wifi_mac_address' => $device_attrs['wifiMacAddress'] ?? null,
+                        'wifi_mac_address' => null,
                         'ethernet_mac_address' => null,
-                        'bluetooth_mac_address' => $device_attrs['bluetoothMacAddress'] ?? null,
+                        'bluetooth_mac_address' => null,
                     ];
                     
                     // Handle dates
@@ -433,9 +433,21 @@ class Applecare_helper
                         $device_info['released_from_org_date'] = date('Y-m-d H:i:s', strtotime($device_attrs['releasedFromOrgDateTime']));
                     }
                     
-                    // Handle array fields
-                    if (!empty($device_attrs['ethernetMacAddress']) && is_array($device_attrs['ethernetMacAddress'])) {
-                        $device_info['ethernet_mac_address'] = implode(', ', array_filter($device_attrs['ethernetMacAddress']));
+                    // Handle MAC address array fields (API 1.5+ returns arrays for all MAC addresses)
+                    if (!empty($device_attrs['wifiMacAddress'])) {
+                        $device_info['wifi_mac_address'] = is_array($device_attrs['wifiMacAddress']) 
+                            ? implode(', ', array_filter($device_attrs['wifiMacAddress'])) 
+                            : $device_attrs['wifiMacAddress'];
+                    }
+                    if (!empty($device_attrs['bluetoothMacAddress'])) {
+                        $device_info['bluetooth_mac_address'] = is_array($device_attrs['bluetoothMacAddress']) 
+                            ? implode(', ', array_filter($device_attrs['bluetoothMacAddress'])) 
+                            : $device_attrs['bluetoothMacAddress'];
+                    }
+                    if (!empty($device_attrs['ethernetMacAddress'])) {
+                        $device_info['ethernet_mac_address'] = is_array($device_attrs['ethernetMacAddress']) 
+                            ? implode(', ', array_filter($device_attrs['ethernetMacAddress'])) 
+                            : $device_attrs['ethernetMacAddress'];
                     }
                 } else {
                     // HTTP 200 but unexpected JSON structure

--- a/locales/en.json
+++ b/locales/en.json
@@ -63,6 +63,7 @@
     "expired": "Expired",
     "inactive": "Expired",
     "inactive_tooltip": "Devices with no active AppleCare coverage",
+    "no_coverage": "Inactive",
     "inactive_title": "Devices with Expired AppleCare",
     "inactive_description": "Devices with no active AppleCare coverage (all plans expired or inactive).",
     "sync_now": "Sync Now",

--- a/sync_applecare.php
+++ b/sync_applecare.php
@@ -61,7 +61,7 @@ echo "================================================\n\n";
 // Check configuration
 $api_base_url = getenv('APPLECARE_API_URL');
 $client_assertion = getenv('APPLECARE_CLIENT_ASSERTION');
-$rate_limit = (int)getenv('APPLECARE_RATE_LIMIT') ?: 20;
+$rate_limit = (int)getenv('APPLECARE_RATE_LIMIT') ?: 40;
 
 if (empty($client_assertion)) {
     die("ERROR: APPLECARE_CLIENT_ASSERTION not set in .env file\n");
@@ -327,9 +327,9 @@ foreach ($devices as $device) {
                     'order_date' => null,
                     'added_to_org_date' => null,
                     'released_from_org_date' => null,
-                    'wifi_mac_address' => $device_attrs['wifiMacAddress'] ?? null,
+                    'wifi_mac_address' => null,
                     'ethernet_mac_address' => null,
-                    'bluetooth_mac_address' => $device_attrs['bluetoothMacAddress'] ?? null,
+                    'bluetooth_mac_address' => null,
                 ];
                 
                 // Handle order date
@@ -347,9 +347,21 @@ foreach ($devices as $device) {
                     $device_info['released_from_org_date'] = date('Y-m-d H:i:s', strtotime($device_attrs['releasedFromOrgDateTime']));
                 }
                 
-                // Handle array fields (ethernetMacAddress)
-                if (!empty($device_attrs['ethernetMacAddress']) && is_array($device_attrs['ethernetMacAddress'])) {
-                    $device_info['ethernet_mac_address'] = implode(', ', array_filter($device_attrs['ethernetMacAddress']));
+                // Handle MAC address array fields (API 1.5+ returns arrays for all MAC addresses)
+                if (!empty($device_attrs['wifiMacAddress'])) {
+                    $device_info['wifi_mac_address'] = is_array($device_attrs['wifiMacAddress']) 
+                        ? implode(', ', array_filter($device_attrs['wifiMacAddress'])) 
+                        : $device_attrs['wifiMacAddress'];
+                }
+                if (!empty($device_attrs['bluetoothMacAddress'])) {
+                    $device_info['bluetooth_mac_address'] = is_array($device_attrs['bluetoothMacAddress']) 
+                        ? implode(', ', array_filter($device_attrs['bluetoothMacAddress'])) 
+                        : $device_attrs['bluetoothMacAddress'];
+                }
+                if (!empty($device_attrs['ethernetMacAddress'])) {
+                    $device_info['ethernet_mac_address'] = is_array($device_attrs['ethernetMacAddress']) 
+                        ? implode(', ', array_filter($device_attrs['ethernetMacAddress'])) 
+                        : $device_attrs['ethernetMacAddress'];
                 }
                 
                 // Note: activation_lock_status and mdm_enrollment_status are not available


### PR DESCRIPTION
Raised the default AppleCare API rate limit from 20 to 40 in configuration, controllers, and documentation. Updated MAC address parsing to support arrays for wifi, ethernet, and bluetooth addresses as returned by API 1.5+, ensuring correct handling and display. Also added a new i18n string for 'no_coverage' and improved UI feedback for devices with no coverage.