### PR TITLE
MDM server tracking, improved sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,39 +137,51 @@ The AppleCare admin page (`Admin` → `Update AppleCare data`) includes:
 
 Based on [AppleCareCoverage.Attributes](https://developer.apple.com/documentation/appleschoolmanagerapi/applecarecoverage/attributes-data.dictionary) and [OrgDevice.Attributes](https://developer.apple.com/documentation/appleschoolmanagerapi/orgdevice/attributes-data.dictionary).
 
-#### AppleCare Coverage Fields
+#### Core Fields
 
-* description - varchar(255) - Description of device coverage.
-* status - varchar(255) - The current status of device coverage. Possible values: 'ACTIVE', 'INACTIVE'
-* startDateTime - DATETIME - Date when coverage period commenced.
-* endDateTime - DATETIME - Date when coverage period ends for the device. This field isn't applicable for AppleCare+ for Business Essentials.
-* contractCancelDateTime - DATETIME - Date when coverage contract was canceled.
-* agreementNumber - varchar(255) - Agreement number associated with device coverage. This field isn't applicable for Limited Warranty and AppleCare+ for Business Essentials.
-* paymentType - varchar(255) - Payment type of device coverage. Possible values: 'ABE_SUBSCRIPTION', 'PAID_UP_FRONT', 'SUBSCRIPTION', 'NONE'
-* isRenewable - Bool - Indicates whether coverage renews after endDateTime for the device. This field isn't applicable for Limited Warranty.
-* isCanceled - Bool - Indicates whether coverage is canceled for the device. This field isn't applicable for Limited Warranty and AppleCare+ for Business Essentials.
-* last_updated - BIGINT - The last time Apple updated this record in Apple Business/School Manager (from API's updatedDateTime).
-* last_fetched - BIGINT - The last time this serial number was checked using the API.
-* sync_in_progress - BOOLEAN - Internal flag to prevent concurrent syncs for the same device.
+* id - VARCHAR(255) - Primary key. **Unique** identifier for each coverage record, provided by the Apple Business/School Manager API (e.g., "H2WH10KXXXXX", "TW1C6LYF46"). Each coverage record from Apple has a unique ID. This is NOT an auto-incrementing integer - it's the coverage ID returned by Apple's API.
+
+* serial_number - VARCHAR(255) - Serial number of the device. Indexed. **NOT unique** - a single device can have multiple coverage records (e.g., Limited Warranty + AppleCare+), each with its own unique `id`.
+* description - VARCHAR(255) - Description of device coverage. Nullable.
+* status - VARCHAR(255) - The current status of device coverage. Possible values: 'ACTIVE', 'INACTIVE'. Nullable, indexed.
+* startDateTime - DATETIME - Date when coverage period commenced. Nullable.
+* endDateTime - DATETIME - Date when coverage period ends for the device. This field isn't applicable for AppleCare+ for Business Essentials. Nullable, indexed.
+* contractCancelDateTime - DATETIME - Date when coverage contract was canceled. Nullable.
+* agreementNumber - VARCHAR(255) - Agreement number associated with device coverage. This field isn't applicable for Limited Warranty and AppleCare+ for Business Essentials. Nullable.
+* paymentType - VARCHAR(255) - Payment type of device coverage. Possible values: 'ABE_SUBSCRIPTION', 'PAID_UP_FRONT', 'SUBSCRIPTION', 'NONE'. Nullable.
+* isRenewable - BOOLEAN - Indicates whether coverage renews after endDateTime for the device. This field isn't applicable for Limited Warranty. Default: false.
+* isCanceled - BOOLEAN - Indicates whether coverage is canceled for the device. This field isn't applicable for Limited Warranty and AppleCare+ for Business Essentials. Default: false.
+* is_primary - BOOLEAN - Flag indicating the primary coverage plan for a device (the plan with the latest end date). Default: 0, indexed.
+* coverage_status - VARCHAR(20) - Calculated coverage status. Possible values: 'active', 'expiring_soon', 'inactive'. Nullable, indexed.
+* last_updated - BIGINT - The last time Apple updated this record in Apple Business/School Manager (from API's updatedDateTime). Nullable.
+* last_fetched - BIGINT - The last time this serial number was checked using the API. Nullable.
+* sync_in_progress - BOOLEAN - Internal flag to prevent concurrent syncs for the same device. Default: 0.
 
 #### Device Information Fields (from Apple Business Manager API)
 
-* model - varchar(255) - Device model name.
-* part_number - varchar(255) - Device part number.
-* product_family - varchar(255) - Product family (e.g., "Mac", "iPad").
-* product_type - varchar(255) - Product type identifier.
-* color - varchar(255) - Device color.
-* device_capacity - varchar(255) - Device storage capacity.
-* device_assignment_status - varchar(255) - Device assignment status (e.g., "ASSIGNED", "UNASSIGNED").
-* purchase_source_type - varchar(255) - Purchase source type (e.g., "RESELLER", "DIRECT").
-* purchase_source_id - varchar(255) - Purchase source identifier (reseller ID).
-* order_number - varchar(255) - Order number.
-* order_date - DATETIME - Order date.
-* added_to_org_date - DATETIME - Date when device was added to organization.
-* released_from_org_date - DATETIME - Date when device was released from organization.
-* wifi_mac_address - varchar(255) - Wi-Fi MAC address.
-* ethernet_mac_address - varchar(255) - Ethernet MAC address(es), comma-separated if multiple.
-* bluetooth_mac_address - varchar(255) - Bluetooth MAC address.
+* model - VARCHAR(255) - Device model name. Nullable.
+* part_number - VARCHAR(255) - Device part number. Nullable.
+* product_family - VARCHAR(255) - Product family (e.g., "Mac", "iPad"). Nullable.
+* product_type - VARCHAR(255) - Product type identifier. Nullable.
+* color - VARCHAR(255) - Device color. Nullable.
+* device_capacity - VARCHAR(255) - Device storage capacity. Nullable.
+* device_assignment_status - VARCHAR(255) - Device assignment status (e.g., "ASSIGNED", "UNASSIGNED"). Nullable, indexed.
+* mdm_server - VARCHAR(255) - MDM server assignment from Apple Business Manager API. Nullable, indexed.
+* purchase_source_type - VARCHAR(255) - Purchase source type (e.g., "RESELLER", "DIRECT"). Nullable, indexed.
+* purchase_source_id - VARCHAR(255) - Purchase source identifier (reseller ID). Nullable.
+* order_number - VARCHAR(255) - Order number. Nullable.
+* order_date - DATETIME - Order date. Nullable.
+* added_to_org_date - DATETIME - Date when device was added to organization. Nullable.
+* released_from_org_date - DATETIME - Date when device was released from organization. Nullable.
+* wifi_mac_address - VARCHAR(255) - Wi-Fi MAC address. Nullable.
+* ethernet_mac_address - VARCHAR(255) - Ethernet MAC address(es), comma-separated if multiple. Nullable.
+* bluetooth_mac_address - VARCHAR(255) - Bluetooth MAC address. Nullable.
+
+#### Indexes
+
+* Primary key: `id`
+* Single column indexes: `serial_number`, `status`, `endDateTime`, `is_primary`, `coverage_status`, `device_assignment_status`, `mdm_server`, `purchase_source_type`
+* Composite indexes: `(serial_number, status)`, `(serial_number, is_primary)`
 
 ### Troubleshooting
 

--- a/applecare_model.php
+++ b/applecare_model.php
@@ -23,6 +23,7 @@ class Applecare_model extends Eloquent
         'color',
         'device_capacity',
         'device_assignment_status',
+        'mdm_server',
         'purchase_source_type',
         'purchase_source_id',
         'order_number',

--- a/applecare_processor.php
+++ b/applecare_processor.php
@@ -2,7 +2,6 @@
 
 use munkireport\processors\Processor;
 use CFPropertyList\CFPropertyList;
-use Illuminate\Database\Capsule\Manager as Capsule;
 
 class Applecare_processor extends Processor
 {
@@ -12,7 +11,9 @@ class Applecare_processor extends Processor
     private function reconnectDatabase()
     {
         try {
-            $connection = Capsule::connection();
+            // Get the Eloquent connection and force reconnect
+            /** @var \Illuminate\Database\Connection $connection */
+            $connection = Applecare_model::getConnectionResolver()->connection();
             $connection->reconnect();
         } catch (\Exception $e) {
             // Log but don't throw - let the retry logic handle it

--- a/locales/en.json
+++ b/locales/en.json
@@ -18,6 +18,7 @@
         "color": "Color",
         "device_capacity": "Device Capacity",
         "device_assignment_status": "Device Assignment",
+        "mdm_server": "MDM Server",
         "enrolled_in_dep": "Enrolled via DEP/ADE",
         "purchase_source_type": "Purchase Source Type",
         "purchase_source_id": "Purchase Source ID",
@@ -79,6 +80,8 @@
         "agreementNumber_title": "Agreement Number",
         "device_assignment_title": "Device Assignment",
         "reseller_title": "Reseller",
-        "enrolled_in_dep_title": "Enrolled via DEP/ADE"
+        "enrolled_in_dep_title": "Enrolled via DEP/ADE",
+        "mdm_server_title": "MDM Servers",
+        "mdm_server_tooltip": "Shows MDM servers assigned to devices. Each entry displays the server name and count of devices assigned to that server."
     }
 }

--- a/migrations/2026_01_21_000001_add_is_primary.php
+++ b/migrations/2026_01_21_000001_add_is_primary.php
@@ -41,9 +41,8 @@ class AddIsPrimary extends Migration
         $now = date('Y-m-d');
         $thirtyDays = date('Y-m-d', strtotime('+30 days'));
         
-        // Get all unique serial numbers
-        $serials = Capsule::table('applecare')
-            ->distinct()
+        // Get all unique serial numbers using Eloquent model
+        $serials = Applecare_model::distinct()
             ->pluck('serial_number');
         
         foreach ($serials as $serial) {
@@ -51,9 +50,8 @@ class AddIsPrimary extends Migration
                 continue;
             }
             
-            // Get all plans for this device
-            $plans = Capsule::table('applecare')
-                ->where('serial_number', $serial)
+            // Get all plans for this device using Eloquent model
+            $plans = Applecare_model::where('serial_number', $serial)
                 ->get();
             
             if ($plans->isEmpty()) {
@@ -64,9 +62,8 @@ class AddIsPrimary extends Migration
             $result = $this->findPrimaryPlanAndStatus($plans, $now, $thirtyDays);
             
             if ($result['id']) {
-                // Mark this plan as primary with coverage_status
-                Capsule::table('applecare')
-                    ->where('id', $result['id'])
+                // Mark this plan as primary with coverage_status using Eloquent model
+                Applecare_model::where('id', $result['id'])
                     ->update([
                         'is_primary' => 1,
                         'coverage_status' => $result['coverage_status']

--- a/migrations/2026_01_21_000002_add_mdm_server.php
+++ b/migrations/2026_01_21_000002_add_mdm_server.php
@@ -1,0 +1,28 @@
+<?php
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+class AddMdmServer extends Migration
+{
+    public function up()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->table('applecare', function (Blueprint $table) {
+            // MDM server assignment from Apple Business Manager API
+            $table->string('mdm_server', 255)->nullable()->after('device_assignment_status');
+            
+            // Index for filtering
+            $table->index('mdm_server');
+        });
+    }
+
+    public function down()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->table('applecare', function (Blueprint $table) {
+            $table->dropIndex(['mdm_server']);
+            $table->dropColumn('mdm_server');
+        });
+    }
+}

--- a/provides.yml
+++ b/provides.yml
@@ -27,6 +27,8 @@ widgets:
         view: applecare_reseller_widget
     applecare_enrolled_in_dep:
         view: applecare_enrolled_in_dep_widget
+    mdm_server:
+        view: applecare_mdm_server_widget
     applecare_total:
         view: applecare_total_detail_widget
 detail_widgets:

--- a/views/applecare_admin.php
+++ b/views/applecare_admin.php
@@ -7,8 +7,8 @@
             <p>Run the AppleCare sync script and inspect the output.</p>
             <div class="alert alert-warning">
                 <strong>Warning:</strong> The sync will stop if you close this page.
-                <br><strong>Server timeout:</strong> <span id="timeout-info">Loading...</span>
-                For large syncs (100+ devices), the sync may timeout. For long-running syncs, use the CLI script instead: <code>php sync_applecare.php</code>
+                <br><strong>Connection info:</strong> <span id="timeout-info">Loading...</span>
+                If the connection times out, the sync will automatically resume from where it left off. For very long or automated syncs, the CLI script is available: <code>php sync_applecare.php</code>
                 <div style="padding-top: 4px;"><strong>Devices to process:</strong> <span id="device-count-display">Loading...</span></div>
             </div>
 
@@ -68,31 +68,17 @@
     
     // Load admin status data (similar to jamf_admin.php)
     $.getJSON(appUrl + '/module/applecare/get_admin_data', function(data) {
-        // Calculate devices per minute from rate limit (80% of limit, 2 requests per device)
+        // Calculate devices per minute from rate limit (80% of limit, 3 requests per device)
         if (data.rate_limit) {
             var effectiveRateLimit = Math.floor(data.rate_limit * 0.8);
-            var requestsPerDevice = 2;
+            var requestsPerDevice = 3;
             devicesPerMinute = effectiveRateLimit / requestsPerDevice;
         }
         
-        // Display actual server timeout info
-        if (data.max_execution_time !== undefined) {
-            var timeoutText;
-            if (data.max_execution_time === 0) {
-                timeoutText = 'No PHP execution time limit (unlimited).';
-            } else {
-                var minutes = Math.floor(data.max_execution_time / 60);
-                var seconds = data.max_execution_time % 60;
-                var timeStr = minutes > 0 ? minutes + ' minute' + (minutes !== 1 ? 's' : '') : '';
-                if (seconds > 0) {
-                    timeStr += (timeStr ? ' ' : '') + seconds + ' second' + (seconds !== 1 ? 's' : '');
-                }
-                timeoutText = 'PHP execution time limit: ' + data.max_execution_time + ' seconds (' + timeStr + ').';
-            }
-            $('#timeout-info').text(timeoutText);
-        } else {
-            $('#timeout-info').text('Unable to determine PHP execution time limit.');
-        }
+        // Display connection timeout info
+        // Note: PHP execution time limit is disabled for sync operations
+        // The actual timeout is from web server/proxy/SSE connection limits
+        $('#timeout-info').text('If connection times out, sync will automatically resume.');
         
         var statusRows = '<table class="table table-striped"><tbody>';
         
@@ -349,20 +335,34 @@
         }
         $btn.prop('disabled', false);
         $excludeCheckbox.prop('disabled', false);
+        
+        // Reset auto-resume state when manually stopped
+        if (typeof resetAutoResumeState === 'function') {
+            resetAutoResumeState();
+        }
     }
 
     function startSync() {
         // Prevent multiple simultaneous syncs
-        if (eventSource) {
+        if (eventSource && eventSource.readyState !== EventSource.CLOSED) {
             return;
         }
 
         var excludeExisting = $excludeCheckbox.is(':checked');
         
+        // Reset auto-resume state on manual start (not auto-resume)
+        if ($status.text() !== 'Auto-resuming...') {
+            resetAutoResumeState();
+        }
+        
         $btn.prop('disabled', true);
         $excludeCheckbox.prop('disabled', true);
         $status.text('Running…');
-        clearOutput();
+        
+        // Don't clear output on auto-resume to preserve history
+        if (autoResumeAttempts === 0) {
+            clearOutput();
+        }
         
         if (excludeExisting) {
             appendOutput('Starting AppleCare sync (excluding devices with existing records)...\n');
@@ -384,10 +384,52 @@
             appendOutput('Connected to sync process...\n');
         };
 
+        eventSource.addEventListener('resume', function(e) {
+            var resumeData = JSON.parse(e.data);
+            totalDevices = resumeData.total || 0;
+            processedDevices = resumeData.processed || 0;
+            
+            if (totalDevices > 0) {
+                $('#sync-progress').removeClass('hide');
+                $('#sync-progress .progress-bar').attr('aria-valuemax', totalDevices);
+                updateProgress();
+                
+                // Update estimated time for remaining devices
+                var remaining = resumeData.remaining || 0;
+                if (remaining > 0) {
+                    var estimatedSeconds = Math.ceil((remaining / devicesPerMinute) * 60);
+                    updateEstimatedTime(estimatedSeconds, remaining);
+                }
+            }
+        });
+
         eventSource.addEventListener('output', function(e) {
             var data = e.data;
             // Unescape newlines
             data = data.replace(/\\n/g, '\n');
+            
+            // Handle RESUME_INFO control message
+            var resumeInfoMatch = data.match(/RESUME_INFO:(\d+):(\d+):(\d+)/);
+            if (resumeInfoMatch) {
+                totalDevices = parseInt(resumeInfoMatch[1]) || 0;
+                processedDevices = parseInt(resumeInfoMatch[2]) || 0;
+                var remaining = parseInt(resumeInfoMatch[3]) || 0;
+                
+                if (totalDevices > 0) {
+                    $('#sync-progress').removeClass('hide');
+                    $('#sync-progress .progress-bar').attr('aria-valuemax', totalDevices);
+                    updateProgress();
+                    
+                    // Update estimated time for remaining devices
+                    if (remaining > 0) {
+                        var estimatedSeconds = Math.ceil((remaining / devicesPerMinute) * 60);
+                        updateEstimatedTime(estimatedSeconds, remaining);
+                    }
+                }
+                
+                // Remove RESUME_INFO from output
+                data = data.replace(/RESUME_INFO:\d+:\d+:\d+\n?/g, '');
+            }
             
             // Remove ESTIMATED_TIME control messages from output (we calculate on frontend now)
             data = data.replace(/ESTIMATED_TIME:\d+:\d+\n?/g, '');
@@ -401,11 +443,14 @@
             // Extract total devices count from "Found X devices" message (appears early)
             var foundMatch = data.match(/Found\s+(\d+)\s+devices/i);
             if (foundMatch) {
-                totalDevices = parseInt(foundMatch[1]) || 0;
-                if (totalDevices > 0) {
-                    $('#sync-progress').removeClass('hide');
-                    $('#sync-progress .progress-bar').attr('aria-valuemax', totalDevices);
-                    updateProgress();
+                // Only set if we haven't already set it from resume
+                if (totalDevices === 0) {
+                    totalDevices = parseInt(foundMatch[1]) || 0;
+                    if (totalDevices > 0) {
+                        $('#sync-progress').removeClass('hide');
+                        $('#sync-progress .progress-bar').attr('aria-valuemax', totalDevices);
+                        updateProgress();
+                    }
                 }
             }
             
@@ -420,10 +465,16 @@
             }
             
             // Extract device index from heartbeat messages
+            // Heartbeat shows absolute position (e.g., "Processing device 150 of 700")
             var heartbeatMatch = data.match(/Processing device\s+(\d+)\s+of\s+(\d+)/i);
             if (heartbeatMatch) {
-                processedDevices = parseInt(heartbeatMatch[1]) || 0;
-                totalDevices = parseInt(heartbeatMatch[2]) || totalDevices;
+                var heartbeatPosition = parseInt(heartbeatMatch[1]) || 0;
+                var heartbeatTotal = parseInt(heartbeatMatch[2]) || totalDevices;
+                
+                // Heartbeat position is 1-indexed, so processed = position - 1
+                processedDevices = Math.max(processedDevices, heartbeatPosition - 1);
+                totalDevices = heartbeatTotal || totalDevices;
+                
                 if (totalDevices > 0 && $('#sync-progress').hasClass('hide')) {
                     $('#sync-progress').removeClass('hide');
                     $('#sync-progress .progress-bar').attr('aria-valuemax', totalDevices);
@@ -435,8 +486,12 @@
             // These appear after "Processing..." messages
             var resultMatch = data.match(/\b(OK|SKIP|ERROR)\s*\(/);
             if (resultMatch) {
-                processedDevices++;
-                updateProgress();
+                // Only increment if we haven't already counted this device
+                // (to avoid double counting on resume)
+                if (processedDevices < totalDevices) {
+                    processedDevices++;
+                    updateProgress();
+                }
             }
             
             // Track errors from output messages
@@ -465,6 +520,9 @@
             $status.text(data.success ? 'Finished' : 'Finished with errors');
             showCompletionMessage(data.success, data);
             
+            // Reset auto-resume state on successful completion
+            resetAutoResumeState();
+            
             // Hide progress bar with fade
             if (totalDevices > 0) {
                 $("#sync-progress").fadeOut(1200, function() {
@@ -481,22 +539,112 @@
             stopSync();
         });
 
+        var autoResumeAttempts = 0;
+        var maxAutoResumeAttempts = 10; // Max 10 auto-resume attempts
+        var autoResumeDelay = 5000; // 5 seconds delay before auto-resume
+        var autoResumeStartTime = null; // Track when auto-resume sequence started
+        var lastProcessedCount = 0; // Track last processed device count
+        var lastFailureTime = null; // Track time of last failure
+        var maxAutoResumeDuration = 3600000; // Max 1 hour of auto-resuming (in milliseconds)
+        var minTimeBetweenFailures = 30000; // Min 30 seconds between failures to count as progress
+        
+        function resetAutoResumeState() {
+            autoResumeAttempts = 0;
+            autoResumeStartTime = null;
+            lastProcessedCount = 0;
+            lastFailureTime = null;
+        }
+        
+        function attemptAutoResume() {
+            var now = Date.now();
+            
+            // Initialize auto-resume start time on first attempt
+            if (autoResumeStartTime === null) {
+                autoResumeStartTime = now;
+            }
+            
+            // Check if we've been auto-resuming for too long
+            if (now - autoResumeStartTime > maxAutoResumeDuration) {
+                appendOutput('\nAuto-resume stopped: Maximum duration (1 hour) exceeded. Please run sync manually.\n');
+                $status.text('Auto-resume timeout');
+                showCompletionMessage(false, {message: 'Auto-resume stopped after 1 hour. Please run sync manually.'});
+                stopSync();
+                resetAutoResumeState();
+                return;
+            }
+            
+            // Check if we're making progress (processed count increased)
+            if (lastFailureTime !== null) {
+                var timeSinceLastFailure = now - lastFailureTime;
+                var currentProcessed = processedDevices || 0;
+                
+                // If we're failing too quickly and not making progress, stop
+                if (timeSinceLastFailure < minTimeBetweenFailures && currentProcessed <= lastProcessedCount) {
+                    appendOutput('\nAuto-resume stopped: No progress detected between failures. Please check connection and run sync manually.\n');
+                    $status.text('Auto-resume stopped');
+                    showCompletionMessage(false, {message: 'Auto-resume stopped: No progress detected. Please run sync manually.'});
+                    stopSync();
+                    resetAutoResumeState();
+                    return;
+                }
+                
+                // Update last processed count if we made progress
+                if (currentProcessed > lastProcessedCount) {
+                    lastProcessedCount = currentProcessed;
+                }
+            } else {
+                lastProcessedCount = processedDevices || 0;
+            }
+            
+            // Check max attempts
+            if (autoResumeAttempts >= maxAutoResumeAttempts) {
+                appendOutput('\nMaximum auto-resume attempts (' + maxAutoResumeAttempts + ') reached. Please run sync manually.\n');
+                $status.text('Auto-resume failed');
+                showCompletionMessage(false, {message: 'Connection failed after ' + maxAutoResumeAttempts + ' auto-resume attempts. Please run sync manually.'});
+                stopSync();
+                resetAutoResumeState();
+                return;
+            }
+            
+            autoResumeAttempts++;
+            lastFailureTime = now;
+            appendOutput('\nAuto-resuming sync in ' + (autoResumeDelay / 1000) + ' seconds... (attempt ' + autoResumeAttempts + '/' + maxAutoResumeAttempts + ')\n');
+            $status.text('Auto-resuming...');
+            
+            setTimeout(function() {
+                // Only auto-resume if connection is still closed (not manually stopped)
+                if (!$btn.prop('disabled') || $status.text() === 'Finished' || $status.text() === 'Finished with errors') {
+                    // User manually stopped or sync completed, don't auto-resume
+                    resetAutoResumeState();
+                    return;
+                }
+                appendOutput('Resuming now...\n');
+                // Close old connection if still exists
+                if (eventSource) {
+                    eventSource.close();
+                    eventSource = null;
+                }
+                startSync();
+            }, autoResumeDelay);
+        }
+
         eventSource.onerror = function(e) {
             if (eventSource.readyState === EventSource.CLOSED) {
                 // Connection closed - sync completed or error occurred
                 if ($status.text() === 'Running…') {
-                    // Unexpected closure
+                    // Unexpected closure - attempt auto-resume
                     appendOutput('\nConnection closed unexpectedly.\n');
-                    $status.text('Connection closed');
-                    showCompletionMessage(false, {message: 'Connection closed unexpectedly. The sync may have timed out or been interrupted.'});
+                    appendOutput('Progress has been saved. Attempting to auto-resume...\n');
+                    attemptAutoResume();
+                } else {
+                    // Normal completion or user stopped
+                    stopSync();
                 }
-                stopSync();
             } else {
-                // Connection error
+                // Connection error - attempt auto-resume
                 appendOutput('\nConnection error occurred.\n');
-                $status.text('Connection error');
-                showCompletionMessage(false, {message: 'Connection error occurred. Please try again.'});
-                stopSync();
+                appendOutput('Progress has been saved. Attempting to auto-resume...\n');
+                attemptAutoResume();
             }
         };
     }

--- a/views/applecare_admin.php
+++ b/views/applecare_admin.php
@@ -7,8 +7,7 @@
             <p>Run the AppleCare sync script and inspect the output.</p>
             <div class="alert alert-warning">
                 <strong>Warning:</strong> The sync will stop if you close this page.
-                <br><strong>Connection info:</strong> <span id="timeout-info">Loading...</span>
-                If the connection times out, the sync will automatically resume from where it left off. For very long or automated syncs, the CLI script is available: <code>php sync_applecare.php</code>
+                <br><strong>Connection info:</strong> If the connection times out, the sync will automatically resume from where it left off. For very long or automated syncs, the CLI script is available: <code>php sync_applecare.php</code>
                 <div style="padding-top: 4px;"><strong>Devices to process:</strong> <span id="device-count-display">Loading...</span></div>
             </div>
 
@@ -78,7 +77,7 @@
         // Display connection timeout info
         // Note: PHP execution time limit is disabled for sync operations
         // The actual timeout is from web server/proxy/SSE connection limits
-        $('#timeout-info').text('If connection times out, sync will automatically resume.');
+        // (Text is now static in HTML, no need to set via JavaScript)
         
         var statusRows = '<table class="table table-striped"><tbody>';
         

--- a/views/applecare_listing.yml
+++ b/views/applecare_listing.yml
@@ -18,6 +18,8 @@ table:
         i18n_header: applecare.column.device_assignment_status
         formatter: format_applecare_device_assignment_status
         filter: device_assignment_status_filter
+    -   column: applecare.mdm_server
+        i18n_header: applecare.column.mdm_server
     -   column: mdm_status.enrolled_in_dep
         i18n_header: applecare.column.enrolled_in_dep
         formatter: format_applecare_enrolled_in_dep
@@ -36,6 +38,7 @@ table:
         formatter: format_applecare_endDateTime
     -   column: applecare.paymentType
         i18n_header: applecare.column.paymentType
+        formatter: format_applecare_paymentType
         filter: paymentType_filter
     -   column: applecare.isRenewable
         i18n_header: applecare.column.isRenewable

--- a/views/applecare_mdm_server_widget.yml
+++ b/views/applecare_mdm_server_widget.yml
@@ -1,0 +1,10 @@
+type: scrollbox
+widget_id: applecare-mdm-server-widget
+api_url: /module/applecare/get_scroll_widget/mdm_server
+i18n_title: applecare.widget.mdm_server_title
+i18n_tooltip: applecare.widget.mdm_server_tooltip
+icon: fa-server
+listing_link: /show/listing/applecare/applecare
+search_key: label
+i18n_empty_result: no_data
+badge: count

--- a/views/applecare_report.yml
+++ b/views/applecare_report.yml
@@ -1,13 +1,14 @@
 row1:
-    applecare_total:
     # applecare_status:
     applecare_device_assignment:
     applecare_enrolled_in_dep:
+    mdm_server:
 row2:
+    applecare_total:
     applecare_isRenewable:
     applecare_isCanceled:
-    applecare_paymentType:
 row3:
+    applecare_paymentType:
     applecare_description:
     applecare_reseller:
 

--- a/views/applecare_tab.php
+++ b/views/applecare_tab.php
@@ -86,7 +86,7 @@ $(document).on('appReady', function(){
                     }
                 }
                 // Separate device info fields from AppleCare fields
-                var deviceInfoFields = ['model', 'part_number', 'product_type', 'color', 'device_assignment_status', 'enrolled_in_dep', 'purchase_source_type', 'purchase_source_name', 'purchase_source_id', 'order_number', 'order_date', 'added_to_org_date', 'released_from_org_date', 'wifi_mac_address', 'ethernet_mac_address', 'bluetooth_mac_address'];
+                var deviceInfoFields = ['model', 'part_number', 'product_type', 'color', 'device_assignment_status', 'mdm_server', 'enrolled_in_dep', 'purchase_source_type', 'purchase_source_name', 'purchase_source_id', 'order_number', 'order_date', 'added_to_org_date', 'released_from_org_date', 'wifi_mac_address', 'ethernet_mac_address', 'bluetooth_mac_address'];
                 var applecareFields = ['status', 'description', 'startDateTime', 'endDateTime', 'paymentType', 'isRenewable', 'isCanceled', 'contractCancelDateTime', 'agreementNumber', 'last_updated'];
             
             // Device Information Table
@@ -145,9 +145,15 @@ $(document).on('appReady', function(){
                     }
                     // Format purchase source type
                     else if (key === 'purchase_source_type') {
+                        var sourceTypeDisplay = {
+                            'MANUALLY_ADDED': 'Manually Added',
+                            'RESELLER': 'Reseller',
+                            'DIRECT': 'Direct',
+                            'UNKNOWN': 'Unknown'
+                        };
                         var typeUpper = String(data[key]).toUpperCase();
-                        var typeDisplay = data[key].charAt(0).toUpperCase() + data[key].slice(1).toLowerCase();
-                        td.text(typeDisplay);
+                        var displayValue = sourceTypeDisplay[typeUpper] || data[key].replace(/_/g, ' ').replace(/\b\w/g, function(l) { return l.toUpperCase(); });
+                        td.text(displayValue);
                     }
                     // Format purchase source name with ID in faded brackets
                     else if (key === 'purchase_source_name') {
@@ -190,6 +196,13 @@ $(document).on('appReady', function(){
                         } else {
                             td.text('');
                         }
+                    }
+                    // Format color - convert to title case (e.g., "SPACE BLACK" -> "Space Black")
+                    else if (key === 'color') {
+                        var colorValue = String(data[key]);
+                        // Convert to title case: lowercase first, then capitalize first letter of each word
+                        var titleCase = colorValue.toLowerCase().replace(/\b\w/g, function(l) { return l.toUpperCase(); });
+                        td.text(titleCase);
                     }
                     // Format MDM enrollment status
                     else if (key === 'mdm_enrollment_status') {
@@ -286,6 +299,18 @@ $(document).on('appReady', function(){
                     }
                     else if (key === 'isCanceled') {
                         td.html(formatBoolean(data[key], 'label-danger', 'label-success'));
+                    }
+                    // Format payment type
+                    else if (key === 'paymentType') {
+                        var paymentTypeDisplay = {
+                            'ABE_SUBSCRIPTION': 'ABE Subscription',
+                            'PAID_UP_FRONT': 'Paid Up Front',
+                            'SUBSCRIPTION': 'Subscription',
+                            'NONE': 'None'
+                        };
+                        var paymentUpper = String(data[key]).toUpperCase();
+                        var displayValue = paymentTypeDisplay[paymentUpper] || data[key];
+                        td.text(displayValue);
                     }
                     // Format dates using helper function
                     else if (key === 'startDateTime' || key === 'contractCancelDateTime' || key === 'endDateTime' || key === 'last_updated') {


### PR DESCRIPTION
 Introduces support for tracking and displaying MDM server assignments for devices in the AppleCare module. Adds a new 'mdm_server' column to the database, updates sync logic to fetch MDM server info from the Apple Business Manager API, and enhances the UI with filtering, formatting, and a new widget for MDM servers. Refactors database queries to use Eloquent models for consistency and maintainability. 